### PR TITLE
Define SQL AST and query result types

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Central export point for all type definitions
+ */
+
+// Database types
+export type {
+  ColumnDefinition,
+  ColumnValue,
+  Row,
+  TableSchema,
+  Table,
+  Database,
+  Index,
+  ConstraintViolation,
+  DatabaseError,
+} from './database';
+
+export { DataType, isValidDataType, isValidColumnValue, isRow } from './database';
+
+// SQL types
+export type {
+  SQLStatement,
+  CreateTableStatement,
+  InsertStatement,
+  SelectStatement,
+  UpdateStatement,
+  DeleteStatement,
+  ShowTablesStatement,
+  DescribeStatement,
+  ColumnConstraint,
+  WhereClause,
+  Condition,
+  LogicalCondition,
+  ComparisonOperator,
+  JoinClause,
+  OrderByClause,
+} from './sql';
+
+export { isSQLStatement } from './sql';
+
+// Query result types
+export type {
+  QueryResult,
+  SelectResult,
+  InsertResult,
+  UpdateResult,
+  DeleteResult,
+  CreateTableResult,
+  ShowTablesResult,
+  DescribeResult,
+  ErrorResult,
+} from './query';
+
+export {
+  isSuccessResult,
+  isErrorResult,
+  isSelectResult,
+  isInsertResult,
+  isUpdateResult,
+  isDeleteResult,
+} from './query';

--- a/lib/types/query.ts
+++ b/lib/types/query.ts
@@ -1,0 +1,109 @@
+import { Row, TableSchema, DatabaseError } from './database';
+
+/**
+ * Query execution result (discriminated union)
+ */
+export type QueryResult =
+  | SelectResult
+  | InsertResult
+  | UpdateResult
+  | DeleteResult
+  | CreateTableResult
+  | ShowTablesResult
+  | DescribeResult
+  | ErrorResult;
+
+// Successful SELECT result
+export interface SelectResult {
+  readonly success: true;
+  readonly type: 'SELECT';
+  readonly rows: ReadonlyArray<Row>;
+  readonly rowCount: number;
+  readonly executionTime: number;
+}
+
+// Successful INSERT result
+export interface InsertResult {
+  readonly success: true;
+  readonly type: 'INSERT';
+  readonly rowsAffected: number;
+  readonly lastInsertId: number | null;
+  readonly executionTime: number;
+}
+
+// Successful UPDATE result
+export interface UpdateResult {
+  readonly success: true;
+  readonly type: 'UPDATE';
+  readonly rowsAffected: number;
+  readonly executionTime: number;
+}
+
+// Successful DELETE result
+export interface DeleteResult {
+  readonly success: true;
+  readonly type: 'DELETE';
+  readonly rowsAffected: number;
+  readonly executionTime: number;
+}
+
+// Successful CREATE TABLE result
+export interface CreateTableResult {
+  readonly success: true;
+  readonly type: 'CREATE_TABLE';
+  readonly tableName: string;
+  readonly executionTime: number;
+}
+
+// SHOW TABLES result
+export interface ShowTablesResult {
+  readonly success: true;
+  readonly type: 'SHOW_TABLES';
+  readonly tables: ReadonlyArray<string>;
+  readonly executionTime: number;
+}
+
+// DESCRIBE table result
+export interface DescribeResult {
+  readonly success: true;
+  readonly type: 'DESCRIBE';
+  readonly schema: TableSchema;
+  readonly executionTime: number;
+}
+
+// Error result
+export interface ErrorResult {
+  readonly success: false;
+  readonly type: 'ERROR';
+  readonly error: DatabaseError;
+  readonly executionTime: number;
+}
+
+/**
+ * Type guards for query results
+ */
+export const isSuccessResult = (
+  result: QueryResult
+): result is Exclude<QueryResult, ErrorResult> => {
+  return result.success === true;
+};
+
+export const isErrorResult = (result: QueryResult): result is ErrorResult => {
+  return result.success === false;
+};
+
+export const isSelectResult = (result: QueryResult): result is SelectResult => {
+  return result.success && result.type === 'SELECT';
+};
+
+export const isInsertResult = (result: QueryResult): result is InsertResult => {
+  return result.success && result.type === 'INSERT';
+};
+
+export const isUpdateResult = (result: QueryResult): result is UpdateResult => {
+  return result.success && result.type === 'UPDATE';
+};
+
+export const isDeleteResult = (result: QueryResult): result is DeleteResult => {
+  return result.success && result.type === 'DELETE';
+};

--- a/lib/types/sql.ts
+++ b/lib/types/sql.ts
@@ -1,0 +1,135 @@
+import { DataType, ColumnValue } from './database';
+
+/**
+ * SQL statement types (discriminated union)
+ */
+export type SQLStatement =
+  | CreateTableStatement
+  | InsertStatement
+  | SelectStatement
+  | UpdateStatement
+  | DeleteStatement
+  | ShowTablesStatement
+  | DescribeStatement;
+
+// CREATE TABLE statement
+export interface CreateTableStatement {
+  readonly type: 'CREATE_TABLE';
+  readonly tableName: string;
+  readonly columns: ReadonlyArray<{
+    readonly name: string;
+    readonly dataType: DataType;
+    readonly constraints: ReadonlyArray<ColumnConstraint>;
+  }>;
+}
+
+// INSERT statement
+export interface InsertStatement {
+  readonly type: 'INSERT';
+  readonly tableName: string;
+  readonly columns: ReadonlyArray<string> | null; 
+  readonly values: ReadonlyArray<ReadonlyArray<ColumnValue>>;
+}
+
+// SELECT statement
+export interface SelectStatement {
+  readonly type: 'SELECT';
+  readonly columns: ReadonlyArray<string> | '*';
+  readonly from: string;
+  readonly where: WhereClause | null;
+  readonly join: JoinClause | null;
+  readonly orderBy: OrderByClause | null;
+  readonly limit: number | null;
+}
+
+// UPDATE statement
+export interface UpdateStatement {
+  readonly type: 'UPDATE';
+  readonly tableName: string;
+  readonly set: ReadonlyArray<{ column: string; value: ColumnValue }>;
+  readonly where: WhereClause | null;
+}
+
+// DELETE statement
+export interface DeleteStatement {
+  readonly type: 'DELETE';
+  readonly from: string;
+  readonly where: WhereClause | null;
+}
+
+// SHOW TABLES statement
+export interface ShowTablesStatement {
+  readonly type: 'SHOW_TABLES';
+}
+
+// DESCRIBE statement
+export interface DescribeStatement {
+  readonly type: 'DESCRIBE';
+  readonly tableName: string;
+}
+
+// Column constraints
+export type ColumnConstraint =
+  | 'PRIMARY KEY'
+  | 'AUTO_INCREMENT'
+  | 'UNIQUE'
+  | 'NOT NULL';
+
+// WHERE clause
+export interface WhereClause {
+  readonly conditions: ReadonlyArray<Condition | LogicalCondition>;
+}
+
+// Single condition
+export interface Condition {
+  readonly type: 'CONDITION';
+  readonly column: string;
+  readonly operator: ComparisonOperator;
+  readonly value: ColumnValue;
+}
+
+// Logical condition (AND/OR)
+export interface LogicalCondition {
+  readonly type: 'LOGICAL';
+  readonly operator: 'AND' | 'OR';
+  readonly left: Condition | LogicalCondition;
+  readonly right: Condition | LogicalCondition;
+}
+
+// Comparison operators
+export type ComparisonOperator = '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE';
+
+// JOIN clause
+export interface JoinClause {
+  readonly type: 'INNER' | 'LEFT' | 'RIGHT';
+  readonly table: string;
+  readonly on: {
+    readonly leftColumn: string;
+    readonly rightColumn: string;
+  };
+}
+
+// ORDER BY clause
+export interface OrderByClause {
+  readonly column: string;
+  readonly direction: 'ASC' | 'DESC';
+}
+
+/**
+ * Type guard for SQL statements
+ */
+export const isSQLStatement = (value: unknown): value is SQLStatement => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const statement = value as { type?: string };
+  return (
+    statement.type === 'CREATE_TABLE' ||
+    statement.type === 'INSERT' ||
+    statement.type === 'SELECT' ||
+    statement.type === 'UPDATE' ||
+    statement.type === 'DELETE' ||
+    statement.type === 'SHOW_TABLES' ||
+    statement.type === 'DESCRIBE'
+  );
+};


### PR DESCRIPTION
### Description

This PR implements the TypeScript definitions for the SQL Abstract Syntax Tree (AST) and the standardized Query Result structures. These types provide the strict contract required for building the SQL parser and the query execution engine, ensuring type safety throughout the request lifecycle.

**Related Issues**
Resolves #9

**Approach**
I created the following type definitions and utilities:

* **SQL AST (`lib/types/sql.ts`):** Defined the `SQLStatement` discriminated union and specific interfaces for supported statements (e.g., `SelectStatement`, `InsertStatement`) and clauses (WHERE, JOIN, ORDER BY).
* **Query Results (`lib/types/query.ts`):** Defined the `QueryResult` union to handle successful operations (selecting data, modifying rows) and error states (`DatabaseError`).
* **Type Guards:** Implemented runtime checks (e.g., `isSQLStatement`, `isSelectResult`) to safely narrow types.
* **Central Export (`lib/types/index.ts`):** Created a barrel file to export all database-related types from a single entry point.

**Testing Performed**

* Ran the TypeScript compiler (`tsc`) to verify the validity of the discriminated unions and ensure no circular dependencies.