### PR TITLE
Add support for ALTER TABLE and DROP TABLE statements

### DIFF
--- a/lib/core/RDBMS.ts
+++ b/lib/core/RDBMS.ts
@@ -6,6 +6,8 @@ import {
   DeleteExecutor,
   CreateTableExecutor,
   MetaExecutor,
+  AlterTableExecutor,
+  DropTableExecutor,
 } from '@/lib/executor';
 import { TableStorage } from '@/lib/storage';
 import { SQLStatement, QueryResult, Database, ErrorResult } from '@/lib/types';
@@ -65,6 +67,12 @@ export class RDBMS {
 
       case 'CREATE_TABLE':
         return CreateTableExecutor.execute(statement, this.tables);
+
+      case 'ALTER_TABLE':
+        return AlterTableExecutor.execute(statement, this.tables);
+
+      case 'DROP_TABLE':
+        return DropTableExecutor.execute(statement, this.tables);
 
       case 'SHOW_TABLES':
         return MetaExecutor.executeShowTables(statement, this.tables);

--- a/lib/executor/AlterTableExecutor.ts
+++ b/lib/executor/AlterTableExecutor.ts
@@ -1,0 +1,179 @@
+import { AlterTableStatement } from '@/lib/types';
+import { TableStorage } from '@/lib/storage';
+import { QueryResult } from '@/lib/types';
+
+export class AlterTableExecutor {
+  static execute(
+    statement: AlterTableStatement,
+    tables: Map<string, TableStorage>
+  ): QueryResult {
+    const { tableName, action } = statement;
+    const table = tables.get(tableName);
+    const startTime = performance.now();
+    if (!table) {
+      return {
+        success: false,
+        type: 'ERROR',
+        error: { type: 'TABLE_NOT_FOUND', tableName },
+        executionTime: performance.now() - startTime,
+      };
+    }
+
+    const schema = {
+      ...table.getSchema(),
+      columns: [...table.getSchema().columns],
+    };
+    let rows = [...table.getRows()];
+
+    switch (action.kind) {
+      case 'ADD_COLUMN': {
+        const { name, dataType, constraints } = action.column;
+        if (schema.columns.some((col) => col.name === name)) {
+          return {
+            success: false,
+            type: 'ERROR',
+            error: {
+              type: 'COLUMN_NOT_FOUND',
+              columnName: name,
+              message: `Column '${name}' already exists`,
+            },
+            executionTime: performance.now() - startTime,
+          };
+        }
+        const newCol = {
+          name,
+          type: dataType,
+          primaryKey: constraints.includes('PRIMARY KEY'),
+          autoIncrement: constraints.includes('AUTO_INCREMENT'),
+          unique: constraints.includes('UNIQUE'),
+          notNull: constraints.includes('NOT NULL'),
+          defaultValue: null,
+        };
+        schema.columns.push(newCol);
+        rows = rows.map((row) => ({ ...row, [name]: null }));
+        table.updateSchemaAndRows(schema, rows);
+        return {
+          success: true,
+          type: 'UPDATE',
+          rowsAffected: 0,
+          executionTime: performance.now() - startTime,
+        };
+      }
+      case 'DROP_COLUMN': {
+        const { columnName } = action;
+        const colIdx = schema.columns.findIndex(
+          (col) => col.name === columnName
+        );
+        if (colIdx === -1) {
+          return {
+            success: false,
+            type: 'ERROR',
+            error: {
+              type: 'COLUMN_NOT_FOUND',
+              columnName,
+              message: `Column '${columnName}' does not exist`,
+            },
+            executionTime: performance.now() - startTime,
+          };
+        }
+        schema.columns.splice(colIdx, 1);
+        rows = rows.map((row) => {
+          const newRow = { ...row };
+          delete newRow[columnName];
+          return newRow;
+        });
+        table.updateSchemaAndRows(schema, rows);
+        return {
+          success: true,
+          type: 'UPDATE',
+          rowsAffected: 0,
+          executionTime: performance.now() - startTime,
+        };
+      }
+      case 'RENAME_COLUMN': {
+        const { oldName, newName } = action;
+        const colIdx = schema.columns.findIndex((col) => col.name === oldName);
+        if (colIdx === -1) {
+          return {
+            success: false,
+            type: 'ERROR',
+            error: {
+              type: 'COLUMN_NOT_FOUND',
+              columnName: oldName,
+              message: `Column '${oldName}' does not exist`,
+            },
+            executionTime: performance.now() - startTime,
+          };
+        }
+        if (schema.columns.some((col) => col.name === newName)) {
+          return {
+            success: false,
+            type: 'ERROR',
+            error: {
+              type: 'COLUMN_NOT_FOUND',
+              columnName: newName,
+              message: `Column '${newName}' already exists`,
+            },
+            executionTime: performance.now() - startTime,
+          };
+        }
+        schema.columns[colIdx] = { ...schema.columns[colIdx]!, name: newName };
+        rows = rows.map((row) => {
+          const newRow = { ...row };
+          newRow[newName] = newRow[oldName]!;
+          delete newRow[oldName];
+          return newRow;
+        });
+        table.updateSchemaAndRows(schema, rows);
+        return {
+          success: true,
+          type: 'UPDATE',
+          rowsAffected: 0,
+          executionTime: performance.now() - startTime,
+        };
+      }
+      case 'MODIFY_COLUMN': {
+        const { name, dataType, constraints } = action.column;
+        const colIdx = schema.columns.findIndex((col) => col.name === name);
+        if (colIdx === -1) {
+          return {
+            success: false,
+            type: 'ERROR',
+            error: {
+              type: 'COLUMN_NOT_FOUND',
+              columnName: name,
+              message: `Column '${name}' does not exist`,
+            },
+            executionTime: performance.now() - startTime,
+          };
+        }
+        schema.columns[colIdx] = {
+          name,
+          type: dataType,
+          primaryKey: constraints.includes('PRIMARY KEY'),
+          autoIncrement: constraints.includes('AUTO_INCREMENT'),
+          unique: constraints.includes('UNIQUE'),
+          notNull: constraints.includes('NOT NULL'),
+          defaultValue: null,
+        };
+        table.updateSchemaAndRows(schema, rows);
+        return {
+          success: true,
+          type: 'UPDATE',
+          rowsAffected: 0,
+          executionTime: performance.now() - startTime,
+        };
+      }
+      default:
+        return {
+          success: false,
+          type: 'ERROR',
+          error: {
+            type: 'EXECUTION_ERROR',
+            message: 'ALTER TABLE action not implemented',
+          },
+          executionTime: performance.now() - startTime,
+        };
+    }
+  }
+}

--- a/lib/executor/DropTableExecutor.ts
+++ b/lib/executor/DropTableExecutor.ts
@@ -1,0 +1,27 @@
+import { DropTableStatement } from '@/lib/types';
+import { TableStorage } from '@/lib/storage';
+import { QueryResult } from '@/lib/types';
+
+export class DropTableExecutor {
+  static execute(
+    statement: DropTableStatement,
+    tables: Map<string, TableStorage>
+  ): QueryResult {
+    const { tableName } = statement;
+    if (!tables.has(tableName)) {
+      return {
+        success: false,
+        type: 'ERROR',
+        error: { type: 'TABLE_NOT_FOUND', tableName },
+        executionTime: 0,
+      };
+    }
+    tables.delete(tableName);
+    return {
+      success: true,
+      type: 'DROP_TABLE',
+      tableName,
+      executionTime: 0,
+    };
+  }
+}

--- a/lib/executor/index.ts
+++ b/lib/executor/index.ts
@@ -1,3 +1,5 @@
+export { AlterTableExecutor } from './AlterTableExecutor';
+export { DropTableExecutor } from './DropTableExecutor';
 export { SelectExecutor } from './SelectExecutor';
 export { InsertExecutor } from './InsertExecutor';
 export { UpdateExecutor } from './UpdateExecutor';

--- a/lib/parser/Tokenizer.ts
+++ b/lib/parser/Tokenizer.ts
@@ -1,6 +1,9 @@
-// Token types for SQL lexical analysis
 export enum TokenType {
-  // Keywords
+  ADD = 'ADD',
+  COLUMN = 'COLUMN',
+  RENAME = 'RENAME',
+  TO = 'TO',
+  MODIFY = 'MODIFY',
   SELECT = 'SELECT',
   FROM = 'FROM',
   WHERE = 'WHERE',
@@ -38,23 +41,19 @@ export enum TokenType {
   TABLES = 'TABLES',
   DESCRIBE = 'DESCRIBE',
 
-  // Data types
   INTEGER = 'INTEGER',
   TEXT = 'TEXT',
   BOOLEAN = 'BOOLEAN',
   REAL = 'REAL',
   DATE = 'DATE',
 
-  // Literals
   STRING = 'STRING',
   NUMBER = 'NUMBER',
   TRUE = 'TRUE',
   FALSE = 'FALSE',
 
-  // Identifiers
   IDENTIFIER = 'IDENTIFIER',
 
-  // Operators
   EQUALS = 'EQUALS',
   NOT_EQUALS = 'NOT_EQUALS',
   GREATER_THAN = 'GREATER_THAN',
@@ -62,7 +61,6 @@ export enum TokenType {
   GREATER_EQUAL = 'GREATER_EQUAL',
   LESS_EQUAL = 'LESS_EQUAL',
 
-  // Punctuation
   COMMA = 'COMMA',
   SEMICOLON = 'SEMICOLON',
   LEFT_PAREN = 'LEFT_PAREN',
@@ -70,19 +68,21 @@ export enum TokenType {
   ASTERISK = 'ASTERISK',
   DOT = 'DOT',
 
-  // Special
   EOF = 'EOF',
 }
 
-// Token representation
 export interface Token {
   readonly type: TokenType;
   readonly value: string;
   readonly position: number;
 }
 
-// Mapping of keywords to token types
 const KEYWORDS: Record<string, TokenType> = {
+  ADD: TokenType.ADD,
+  COLUMN: TokenType.COLUMN,
+  RENAME: TokenType.RENAME,
+  TO: TokenType.TO,
+  MODIFY: TokenType.MODIFY,
   SELECT: TokenType.SELECT,
   FROM: TokenType.FROM,
   WHERE: TokenType.WHERE,
@@ -128,7 +128,6 @@ const KEYWORDS: Record<string, TokenType> = {
   FALSE: TokenType.FALSE,
 };
 
-// Tokenizer class for SQL input
 export class Tokenizer {
   private input: string;
   private position: number;
@@ -140,53 +139,44 @@ export class Tokenizer {
     this.currentChar = input.length > 0 ? (input[0] ?? null) : null;
   }
 
-  // Main method to tokenize the input
   tokenize(): Token[] {
     const tokens: Token[] = [];
 
     while (this.currentChar !== null) {
-      // Skip whitespace
       if (this.isWhitespace(this.currentChar)) {
         this.skipWhitespace();
         continue;
       }
 
-      // Skip comments
       if (this.currentChar === '-' && this.peek() === '-') {
         this.skipComment();
         continue;
       }
 
-      // String literals
       if (this.currentChar === "'" || this.currentChar === '"') {
         tokens.push(this.readString());
         continue;
       }
 
-      // Numbers
       if (this.isDigit(this.currentChar)) {
         tokens.push(this.readNumber());
         continue;
       }
 
-      // Identifiers and keywords
       if (this.isAlpha(this.currentChar)) {
         tokens.push(this.readIdentifierOrKeyword());
         continue;
       }
 
-      // Operators and punctuation
       const operator = this.readOperator();
       if (operator) {
         tokens.push(operator);
         continue;
       }
 
-      // Unknown character - skip it
       this.advance();
     }
 
-    // Add EOF token
     tokens.push({
       type: TokenType.EOF,
       value: '',
@@ -196,7 +186,6 @@ export class Tokenizer {
     return tokens;
   }
 
-  // Advances the current position and updates currentChar
   private advance(): void {
     this.position++;
     this.currentChar =
@@ -205,20 +194,17 @@ export class Tokenizer {
         : null;
   }
 
-  // Peeks at the next character without advancing
   private peek(offset: number = 1): string | null {
     const peekPos = this.position + offset;
     return peekPos < this.input.length ? (this.input[peekPos] ?? null) : null;
   }
 
-  // Skips whitespace characters
   private skipWhitespace(): void {
     while (this.currentChar !== null && this.isWhitespace(this.currentChar)) {
       this.advance();
     }
   }
 
-  // Skips single-line comments
   private skipComment(): void {
     while (this.currentChar !== null && this.currentChar !== '\n') {
       this.advance();
@@ -228,7 +214,6 @@ export class Tokenizer {
     }
   }
 
-  // Reads a string literal
   private readString(): Token {
     const startPos = this.position;
     const quote = this.currentChar;
@@ -236,7 +221,6 @@ export class Tokenizer {
 
     let value = '';
     while (this.currentChar !== null && this.currentChar !== quote) {
-      // Handle escaped quotes
       if (this.currentChar === '\\' && this.peek() === quote) {
         this.advance();
         value += quote;
@@ -247,7 +231,7 @@ export class Tokenizer {
       }
     }
 
-    this.advance(); // Skip closing quote
+    this.advance();
 
     return {
       type: TokenType.STRING,
@@ -256,7 +240,6 @@ export class Tokenizer {
     };
   }
 
-  // Reads a number (integer or real)
   private readNumber(): Token {
     const startPos = this.position;
     let value = '';
@@ -266,7 +249,6 @@ export class Tokenizer {
       this.advance();
     }
 
-    // Check for decimal point
     if (this.currentChar === '.' && this.peek() && this.isDigit(this.peek()!)) {
       value += this.currentChar;
       this.advance();
@@ -284,7 +266,6 @@ export class Tokenizer {
     };
   }
 
-  // Reads an identifier or keyword
   private readIdentifierOrKeyword(): Token {
     const startPos = this.position;
     let value = '';
@@ -307,14 +288,12 @@ export class Tokenizer {
     };
   }
 
-  // Reads operators and punctuation
   private readOperator(): Token | null {
     const startPos = this.position;
     const char = this.currentChar;
 
     if (!char) return null;
 
-    // Two-character operators
     if (char === '!' && this.peek() === '=') {
       this.advance();
       this.advance();
@@ -333,7 +312,6 @@ export class Tokenizer {
       return { type: TokenType.LESS_EQUAL, value: '<=', position: startPos };
     }
 
-    // Single-character operators
     const singleCharTokens: Record<string, TokenType> = {
       '=': TokenType.EQUALS,
       '>': TokenType.GREATER_THAN,
@@ -355,22 +333,18 @@ export class Tokenizer {
     return null;
   }
 
-  // Helper: checks if character is whitespace
   private isWhitespace(char: string): boolean {
     return /\s/.test(char);
   }
 
-  // Helper: checks if character is a digit
   private isDigit(char: string): boolean {
     return /[0-9]/.test(char);
   }
 
-  // Helper: checks if character is alphabetic
   private isAlpha(char: string): boolean {
     return /[a-zA-Z]/.test(char);
   }
 
-  // Helper: checks if character is alphanumeric
   private isAlphaNumeric(char: string): boolean {
     return /[a-zA-Z0-9]/.test(char);
   }

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -1,4 +1,3 @@
-// Supported SQL data types
 export enum DataType {
   INTEGER = 'INTEGER',
   TEXT = 'TEXT',
@@ -7,7 +6,6 @@ export enum DataType {
   DATE = 'DATE',
 }
 
-// Column definition for a table schema
 export interface ColumnDefinition {
   readonly name: string;
   readonly type: DataType;
@@ -18,13 +16,10 @@ export interface ColumnDefinition {
   readonly defaultValue: ColumnValue | null;
 }
 
-// Valid column value types
 export type ColumnValue = string | number | boolean | Date | null;
 
-// Row data structure (record in a table)
 export type Row = Record<string, ColumnValue>;
 
-// Table schema definition
 export interface TableSchema {
   readonly name: string;
   readonly columns: ReadonlyArray<ColumnDefinition>;
@@ -32,14 +27,12 @@ export interface TableSchema {
   readonly uniqueColumns: ReadonlyArray<string>;
 }
 
-// Index structure for fast lookups
 export interface Index {
   readonly columnName: string;
   readonly unique: boolean;
   readonly entries: Map<ColumnValue, Set<number>>;
 }
 
-// Complete table data structure
 export interface Table {
   readonly schema: TableSchema;
   readonly rows: Row[];
@@ -47,12 +40,10 @@ export interface Table {
   readonly autoIncrementCounter: number;
 }
 
-// Database structure containing all tables
 export interface Database {
   readonly tables: Map<string, Table>;
 }
 
-//Details about a constraint violation error.
 export interface ConstraintViolation {
   readonly type: 'PRIMARY_KEY' | 'UNIQUE' | 'NOT_NULL' | 'TYPE_MISMATCH';
   readonly column: string;
@@ -60,11 +51,14 @@ export interface ConstraintViolation {
   readonly message: string;
 }
 
-// Database error types for common failure cases.
 export type DatabaseError =
   | { readonly type: 'TABLE_NOT_FOUND'; readonly tableName: string }
   | { readonly type: 'TABLE_ALREADY_EXISTS'; readonly tableName: string }
-  | { readonly type: 'COLUMN_NOT_FOUND'; readonly columnName: string }
+  | {
+      readonly type: 'COLUMN_NOT_FOUND';
+      readonly columnName: string;
+      readonly message?: string;
+    }
   | {
       readonly type: 'CONSTRAINT_VIOLATION';
       readonly violation: ConstraintViolation;
@@ -72,7 +66,6 @@ export type DatabaseError =
   | { readonly type: 'SYNTAX_ERROR'; readonly message: string }
   | { readonly type: 'EXECUTION_ERROR'; readonly message: string };
 
-// Type guards for runtime type checking of database types.
 export const isValidDataType = (value: string): value is DataType => {
   return Object.values(DataType).includes(value as DataType);
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,8 +1,3 @@
-/**
- * Central export point for all type definitions
- */
-
-// Database types
 export type {
   ColumnDefinition,
   ColumnValue,
@@ -32,6 +27,9 @@ export type {
   DeleteStatement,
   ShowTablesStatement,
   DescribeStatement,
+  AlterTableStatement,
+  AlterTableAction,
+  DropTableStatement,
   ColumnConstraint,
   WhereClause,
   Condition,

--- a/lib/types/query.ts
+++ b/lib/types/query.ts
@@ -1,8 +1,5 @@
 import { Row, TableSchema, DatabaseError } from './database';
 
-/**
- * Query execution result (discriminated union)
- */
 export type QueryResult =
   | SelectResult
   | InsertResult
@@ -11,9 +8,15 @@ export type QueryResult =
   | CreateTableResult
   | ShowTablesResult
   | DescribeResult
+  | DropTableResult
   | ErrorResult;
+export interface DropTableResult {
+  readonly success: true;
+  readonly type: 'DROP_TABLE';
+  readonly tableName: string;
+  readonly executionTime: number;
+}
 
-// Successful SELECT result
 export interface SelectResult {
   readonly success: true;
   readonly type: 'SELECT';
@@ -22,7 +25,6 @@ export interface SelectResult {
   readonly executionTime: number;
 }
 
-// Successful INSERT result
 export interface InsertResult {
   readonly success: true;
   readonly type: 'INSERT';
@@ -31,7 +33,6 @@ export interface InsertResult {
   readonly executionTime: number;
 }
 
-// Successful UPDATE result
 export interface UpdateResult {
   readonly success: true;
   readonly type: 'UPDATE';
@@ -39,7 +40,6 @@ export interface UpdateResult {
   readonly executionTime: number;
 }
 
-// Successful DELETE result
 export interface DeleteResult {
   readonly success: true;
   readonly type: 'DELETE';
@@ -47,7 +47,6 @@ export interface DeleteResult {
   readonly executionTime: number;
 }
 
-// Successful CREATE TABLE result
 export interface CreateTableResult {
   readonly success: true;
   readonly type: 'CREATE_TABLE';
@@ -55,7 +54,6 @@ export interface CreateTableResult {
   readonly executionTime: number;
 }
 
-// SHOW TABLES result
 export interface ShowTablesResult {
   readonly success: true;
   readonly type: 'SHOW_TABLES';
@@ -63,7 +61,6 @@ export interface ShowTablesResult {
   readonly executionTime: number;
 }
 
-// DESCRIBE table result
 export interface DescribeResult {
   readonly success: true;
   readonly type: 'DESCRIBE';
@@ -71,7 +68,6 @@ export interface DescribeResult {
   readonly executionTime: number;
 }
 
-// Error result
 export interface ErrorResult {
   readonly success: false;
   readonly type: 'ERROR';
@@ -79,9 +75,7 @@ export interface ErrorResult {
   readonly executionTime: number;
 }
 
-/**
- * Type guards for query results
- */
+// Type guards for QueryResult types
 export const isSuccessResult = (
   result: QueryResult
 ): result is Exclude<QueryResult, ErrorResult> => {


### PR DESCRIPTION
### Description

This PR significantly expands the Data Definition Language (DDL) capabilities of the RDBMS. It introduces the ability to modify existing table schemas (`ALTER TABLE`) and remove tables entirely (`DROP TABLE`). This allows for database evolution and cleanup, which is critical for real-world usage and the demo application.

**Related Issues**
Resolves #31

**Approach**
I implemented the changes across the full stack (Parser -> Executor -> Storage):

* **Parser & Tokenizer (`lib/parser/`):**
* Added keywords: `ALTER`, `DROP`, `ADD`, `COLUMN`, `MODIFY`, `RENAME`.
* Extended `SQLParser` to generate ASTs for `ALTER TABLE` (supporting `ADD` and `DROP` column) and `DROP TABLE` statements.


* **Storage Engine (`lib/storage/Table.ts`):**
* Added `updateSchemaAndRows()`: This critical method handles the low-level data transformation. When adding a column, it backfills existing rows with `NULL`. When dropping a column, it strips that key from every row object in memory.


* **Executors (`lib/executor/`):**
* **`AlterTableExecutor`:** Orchestrates the schema validation (ensuring the column doesn't already exist or does exist, depending on the action) and calls the storage update method.
* **`DropTableExecutor`:** Handles the removal of the `TableStorage` instance from the database registry.


* **Orchestration (`lib/core/RDBMS.ts`):**
* Wired the new AST types to their respective executors in the main `execute()` switch.
