### PR TITLE
Refactor data synchronization and add cascading deletes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,9 +10,6 @@ type Tab = 'demo' | 'repl';
 
 const Home = () => {
   const [activeTab, setActiveTab] = useState<Tab>('demo');
-  const [dataVersion, setDataVersion] = useState(0);
-
-  const handleDataChanged = () => setDataVersion((v) => v + 1);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
@@ -92,7 +89,7 @@ const Home = () => {
                 and JOIN queries.
               </p>
             </div>
-            <DemoApp key={dataVersion} />
+            <DemoApp />
           </div>
         )}
 
@@ -107,7 +104,7 @@ const Home = () => {
                 SELECT, UPDATE, DELETE, and more.
               </p>
             </div>
-            <REPLTerminal onDataChanged={handleDataChanged} />
+            <REPLTerminal />
           </div>
         )}
       </main>

--- a/components/repl/REPLTerminal.tsx
+++ b/components/repl/REPLTerminal.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { useExecuteSQLMutation } from '@/app/services/api';
+import { useDispatch } from 'react-redux';
+import { useExecuteSQLMutation, api } from '@/app/services/api';
 import { ResultFormatter } from '@/lib';
 import { Button, Textarea, Card } from '@/components/ui';
 import { Play, Trash2, Clock } from 'lucide-react';
-import type { QueryHistoryItem, REPLTerminalProps } from '@/lib/types/repl';
+import type { QueryHistoryItem } from '@/lib/types/repl';
 
-const REPLTerminal = ({ onDataChanged }: REPLTerminalProps) => {
+const REPLTerminal = () => {
+  const dispatch = useDispatch();
   const [query, setQuery] = useState('');
   const [history, setHistory] = useState<QueryHistoryItem[]>([]);
   const [isExecuting, setIsExecuting] = useState(false);
@@ -33,8 +35,9 @@ const REPLTerminal = ({ onDataChanged }: REPLTerminalProps) => {
         'CREATE_TABLE',
         'DROP_TABLE',
       ].includes(result.type);
-      if (result.success && mutating && onDataChanged) {
-        onDataChanged();
+      if (result.success && mutating) {
+        // Invalidate RTK Query cache for both tables
+        dispatch(api.util.invalidateTags(['Customer', 'Order']));
       }
       setHistory((prev) => [
         ...prev,


### PR DESCRIPTION
This PR improves data consistency by switching to RTK Query cache invalidation and enforcing referential integrity in the SQL adapter.

* Replace manual data versioning with RTK Query cache invalidation tags
* Update REPL terminal to invalidate 'Customer' and 'Order' tags on mutation
* Implement cascading deletes in Prisma adapter (delete orders before customer)
* Remove obsolete dataVersion props from main page components

Resolves: #49